### PR TITLE
add moneroTs default export

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -378,3 +378,174 @@ export {
   openWalletFull,
   createWalletKeys
 };
+
+// export default object with aggregate of all exports
+const moneroTs = {
+  GenUtils,
+  Filter,
+  MoneroError,
+  HttpClient,
+  LibraryUtils,
+  MoneroRpcConnection,
+  MoneroRpcError,
+  SslOptions,
+  TaskLooper,
+  ConnectionType,
+  MoneroAltChain,
+  MoneroBan,
+  MoneroBlockHeader,
+  MoneroBlock,
+  MoneroBlockTemplate,
+  MoneroConnectionSpan,
+  MoneroDaemonConfig,
+  MoneroDaemonInfo,
+  MoneroDaemonListener,
+  MoneroDaemonSyncInfo,
+  MoneroDaemonUpdateCheckResult,
+  MoneroDaemonUpdateDownloadResult,
+  MoneroFeeEstimate,
+  MoneroHardForkInfo,
+  MoneroKeyImage,
+  MoneroKeyImageSpentStatus,
+  MoneroMinerTxSum,
+  MoneroMiningStatus,
+  MoneroNetworkType,
+  MoneroOutput,
+  MoneroOutputHistogramEntry,
+  MoneroSubmitTxResult,
+  MoneroTx,
+  MoneroTxPoolStats,
+  MoneroVersion,
+  MoneroPeer,
+  MoneroPruneResult,
+  MoneroAccount,
+  MoneroAccountTag,
+  MoneroAddressBookEntry,
+  MoneroCheck,
+  MoneroCheckReserve,
+  MoneroCheckTx,
+  MoneroDestination,
+  MoneroIntegratedAddress,
+  MoneroKeyImageImportResult,
+  MoneroMultisigInfo,
+  MoneroMultisigInitResult,
+  MoneroMultisigSignResult,
+  MoneroOutputWallet,
+  MoneroOutputQuery,
+  MoneroTxPriority,
+  MoneroTxConfig,
+  MoneroSubaddress,
+  MoneroSyncResult,
+  MoneroTransfer,
+  MoneroIncomingTransfer,
+  MoneroOutgoingTransfer,
+  MoneroTransferQuery,
+  MoneroTxSet,
+  MoneroTxWallet,
+  MoneroTxQuery,
+  MoneroWalletListener,
+  MoneroWalletConfig,
+  MoneroMessageSignatureType,
+  MoneroMessageSignatureResult,
+  MoneroConnectionManagerListener,
+  MoneroConnectionManager,
+  MoneroDaemon,
+  MoneroWallet,
+  MoneroDaemonRpc,
+  MoneroWalletRpc,
+  MoneroWalletKeys,
+  MoneroWalletFull,
+  MoneroUtils,
+  ThreadPool,
+
+  // global functions
+  getVersion,
+  connectToDaemonRpc,
+  connectToWalletRpc,
+  createWalletFull,
+  openWalletFull,
+  createWalletKeys
+}
+export default moneroTs;
+
+// augment global scope with same namespace as default export
+declare global {
+  namespace moneroTs {
+    type GenUtils = InstanceType<typeof import("./index").GenUtils>;
+    type Filter = InstanceType<typeof import("./index").Filter>;
+    type MoneroError = InstanceType<typeof import("./index").MoneroError>;
+    type HttpClient = InstanceType<typeof import("./index").HttpClient>;
+    type LibraryUtils = InstanceType<typeof import("./index").LibraryUtils>;
+    type MoneroRpcConnection = InstanceType<typeof import("./index").MoneroRpcConnection>;
+    type MoneroRpcError = InstanceType<typeof import("./index").MoneroRpcError>;
+    type SslOptions = InstanceType<typeof import("./index").SslOptions>;
+    type TaskLooper = InstanceType<typeof import("./index").TaskLooper>;
+    type ConnectionType = import("./index").ConnectionType; // type alias for enum
+    type MoneroAltChain = InstanceType<typeof import("./index").MoneroAltChain>;
+    type MoneroBan = InstanceType<typeof import("./index").MoneroBan>;
+    type MoneroBlockHeader = InstanceType<typeof import("./index").MoneroBlockHeader>;
+    type MoneroBlock = InstanceType<typeof import("./index").MoneroBlock>;
+    type MoneroBlockTemplate = InstanceType<typeof import("./index").MoneroBlockTemplate>;
+    type MoneroConnectionSpan = InstanceType<typeof import("./index").MoneroConnectionSpan>;
+    type MoneroDaemonConfig = InstanceType<typeof import("./index").MoneroDaemonConfig>;
+    type MoneroDaemonInfo = InstanceType<typeof import("./index").MoneroDaemonInfo>;
+    type MoneroDaemonListener = InstanceType<typeof import("./index").MoneroDaemonListener>;
+    type MoneroDaemonSyncInfo = InstanceType<typeof import("./index").MoneroDaemonSyncInfo>;
+    type MoneroDaemonUpdateCheckResult = InstanceType<typeof import("./index").MoneroDaemonUpdateCheckResult>;
+    type MoneroDaemonUpdateDownloadResult = InstanceType<typeof import("./index").MoneroDaemonUpdateDownloadResult>;
+    type MoneroFeeEstimate = InstanceType<typeof import("./index").MoneroFeeEstimate>;
+    type MoneroHardForkInfo = InstanceType<typeof import("./index").MoneroHardForkInfo>;
+    type MoneroKeyImage = InstanceType<typeof import("./index").MoneroKeyImage>;
+    type MoneroKeyImageSpentStatus = import("./index").MoneroKeyImageSpentStatus;
+    type MoneroMinerTxSum = InstanceType<typeof import("./index").MoneroMinerTxSum>;
+    type MoneroMiningStatus = InstanceType<typeof import("./index").MoneroMiningStatus>;
+    type MoneroNetworkType = InstanceType<typeof import("./index").MoneroNetworkType>;
+    type MoneroOutput = InstanceType<typeof import("./index").MoneroOutput>;
+    type MoneroOutputHistogramEntry = InstanceType<typeof import("./index").MoneroOutputHistogramEntry>;
+    type MoneroSubmitTxResult = InstanceType<typeof import("./index").MoneroSubmitTxResult>;
+    type MoneroTx = InstanceType<typeof import("./index").MoneroTx>;
+    type MoneroTxPoolStats = InstanceType<typeof import("./index").MoneroTxPoolStats>;
+    type MoneroVersion = InstanceType<typeof import("./index").MoneroVersion>;
+    type MoneroPeer = InstanceType<typeof import("./index").MoneroPeer>;
+    type MoneroPruneResult = InstanceType<typeof import("./index").MoneroPruneResult>;
+    type MoneroAccount = InstanceType<typeof import("./index").MoneroAccount>;
+    type MoneroAccountTag = InstanceType<typeof import("./index").MoneroAccountTag>;
+    type MoneroAddressBookEntry = InstanceType<typeof import("./index").MoneroAddressBookEntry>;
+    type MoneroCheck = InstanceType<typeof import("./index").MoneroCheck>;
+    type MoneroCheckReserve = InstanceType<typeof import("./index").MoneroCheckReserve>;
+    type MoneroCheckTx = InstanceType<typeof import("./index").MoneroCheckTx>;
+    type MoneroDestination = InstanceType<typeof import("./index").MoneroDestination>;
+    type MoneroIntegratedAddress = InstanceType<typeof import("./index").MoneroIntegratedAddress>;
+    type MoneroKeyImageImportResult = InstanceType<typeof import("./index").MoneroKeyImageImportResult>;
+    type MoneroMultisigInfo = InstanceType<typeof import("./index").MoneroMultisigInfo>;
+    type MoneroMultisigInitResult = InstanceType<typeof import("./index").MoneroMultisigInitResult>;
+    type MoneroMultisigSignResult = InstanceType<typeof import("./index").MoneroMultisigSignResult>;
+    type MoneroOutputWallet = InstanceType<typeof import("./index").MoneroOutputWallet>;
+    type MoneroOutputQuery = InstanceType<typeof import("./index").MoneroOutputQuery>;
+    type MoneroTxPriority = import("./index").MoneroTxPriority;
+    type MoneroTxConfig = InstanceType<typeof import("./index").MoneroTxConfig>;
+    type MoneroSubaddress = InstanceType<typeof import("./index").MoneroSubaddress>;
+    type MoneroSyncResult = InstanceType<typeof import("./index").MoneroSyncResult>;
+    type MoneroTransfer = InstanceType<typeof import("./index").MoneroTransfer>;
+    type MoneroIncomingTransfer = InstanceType<typeof import("./index").MoneroIncomingTransfer>;
+    type MoneroOutgoingTransfer = InstanceType<typeof import("./index").MoneroOutgoingTransfer>;
+    type MoneroTransferQuery = InstanceType<typeof import("./index").MoneroTransferQuery>;
+    type MoneroTxSet = InstanceType<typeof import("./index").MoneroTxSet>;
+    type MoneroTxWallet = InstanceType<typeof import("./index").MoneroTxWallet>;
+    type MoneroTxQuery = InstanceType<typeof import("./index").MoneroTxQuery>;
+    type MoneroWalletListener = InstanceType<typeof import("./index").MoneroWalletListener>;
+    type MoneroWalletConfig = InstanceType<typeof import("./index").MoneroWalletConfig>;
+    type MoneroMessageSignatureType = import("./index").MoneroMessageSignatureType;
+    type MoneroMessageSignatureResult = InstanceType<typeof import("./index").MoneroMessageSignatureResult>;
+    type MoneroConnectionManagerListener = InstanceType<typeof import("./index").MoneroConnectionManagerListener>;
+    type MoneroConnectionManager = InstanceType<typeof import("./index").MoneroConnectionManager>;
+    type MoneroDaemon = InstanceType<typeof import("./index").MoneroDaemon>;
+    type MoneroWallet = InstanceType<typeof import("./index").MoneroWallet>;
+    type MoneroDaemonRpc = InstanceType<typeof import("./index").MoneroDaemonRpc>;
+    type MoneroWalletRpc = InstanceType<typeof import("./index").MoneroWalletRpc>;
+    type MoneroWalletKeys = InstanceType<typeof import("./index").MoneroWalletKeys>;
+    type MoneroWalletFull = InstanceType<typeof import("./index").MoneroWalletFull>;
+    type MoneroUtils = InstanceType<typeof import("./index").MoneroUtils>;
+    type ThreadPool = InstanceType<typeof import("./index").ThreadPool>;
+  }
+}

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@
 
 // --------------------------------- IMPORTS ----------------------------------
 
-// See the full model specification: http://moneroecosystem.org/monero-java/monero-spec.pdf
+// See the full model specification: https://woodser.github.io/monero-java/monero-spec.pdf
 
 // import common models
 import GenUtils from "./src/main/ts/common/GenUtils";
@@ -94,7 +94,7 @@ import ThreadPool from "./src/main/ts/common/ThreadPool";
 
 /**
  * <p>Get the version of the monero-ts library.<p>
- * 
+ *
  * @return {string} the version of this monero-ts library
  */
 function getVersion() {
@@ -103,9 +103,9 @@ function getVersion() {
 
 /**
  * <p>Create a client connected to monerod.<p>
- * 
+ *
  * <p>Examples:<p>
- * 
+ *
  * <code>
  * let daemon = await moneroTs.connectToDaemonRpc("http://localhost:38081");<br>
  * </code><br>
@@ -124,7 +124,7 @@ function getVersion() {
  * &nbsp;&nbsp; cmd: ["path/to/monerod", ...params...],<br>
  * });
  * </code>
- * 
+ *
  * @param {string|Partial<MoneroRpcConnection>|Partial<MoneroDaemonConfig>|string[]} uriOrConfig - uri or rpc connection or config or terminal parameters to connect to monerod
  * @param {string} [username] - username to authenticate with monerod
  * @param {string} [password] - password to authenticate with monerod
@@ -136,9 +136,9 @@ function connectToDaemonRpc(uriOrConfig: string | Partial<MoneroRpcConnection> |
 
 /**
  * <p>Create a client connected to monero-wallet-rpc.</p>
- * 
+ *
  * <p>Examples:</p>
- * 
+ *
  * <code>
  * let walletRpc = await moneroTs.connectToWalletRpc({<br>
  * &nbsp;&nbsp; uri: "http://localhost:38081",<br>
@@ -161,7 +161,7 @@ function connectToDaemonRpc(uriOrConfig: string | Partial<MoneroRpcConnection> |
  * &nbsp;&nbsp; "--rpc-access-control-origins", "http://localhost:8080"<br>
  * &nbsp;]});
  * </code>
- * 
+ *
  * @param {string|Partial<MoneroRpcConnection>|Partial<MoneroWalletConfig>|string[]} uriOrConfig - uri or rpc connection or config or terminal parameters to connect to monero-wallet-rpc
  * @param {string} [username] - username to authenticate with monero-wallet-rpc
  * @param {string} [password] - password to authenticate with monero-wallet-rpc
@@ -170,12 +170,12 @@ function connectToDaemonRpc(uriOrConfig: string | Partial<MoneroRpcConnection> |
 function connectToWalletRpc(uriOrConfig: string | Partial<MoneroRpcConnection> | Partial<MoneroWalletConfig> | string[], username?: string, password?: string): Promise<MoneroWalletRpc> {
   return MoneroWalletRpc.connectToWalletRpc(uriOrConfig, username, password);
 }
-  
+
 /**
  * <p>Create a Monero wallet using client-side WebAssembly bindings to monero-project's wallet2 in C++.<p>
- * 
+ *
  * <p>Example:</p>
- * 
+ *
  * <code>
  * const wallet = await moneroTs.createWalletFull({<br>
  * &nbsp;&nbsp; path: "./test_wallets/wallet1", // leave blank for in-memory wallet<br>
@@ -202,7 +202,7 @@ function connectToWalletRpc(uriOrConfig: string | Partial<MoneroRpcConnection> |
  * &nbsp;&nbsp; }<br>
  * });
  * </code>
- * 
+ *
  * @param {Partial<MoneroWalletConfig>} config - MoneroWalletConfig or equivalent config object
  * @param {string} [config.path] - path of the wallet to create (optional, in-memory wallet if not given)
  * @param {string} [config.password] - password of the wallet to create
@@ -230,22 +230,22 @@ function createWalletFull(config: Partial<MoneroWalletConfig>): Promise<MoneroWa
 
 /**
  * <p>Open an existing Monero wallet using client-side WebAssembly bindings to monero-project's wallet2 in C++.<p>
- * 
+ *
  * <p>Example:<p>
- * 
+ *
  * <code>
  * const wallet = await moneroTs.openWalletFull({<br>
  * &nbsp;&nbsp; path: "./wallets/wallet1",<br>
  * &nbsp;&nbsp; password: "supersecretpassword",<br>
  * &nbsp;&nbsp; networkType: moneroTs.MoneroNetworkType.STAGENET,<br>
-* &nbsp;&nbsp; server: { // daemon configuration<br>
+ * &nbsp;&nbsp; server: { // daemon configuration<br>
  * &nbsp;&nbsp;&nbsp;&nbsp; uri: "http://localhost:38081",<br>
  * &nbsp;&nbsp;&nbsp;&nbsp; username: "superuser",<br>
  * &nbsp;&nbsp;&nbsp;&nbsp; password: "abctesting123"<br>
  * &nbsp;&nbsp; }<br>
  * });
  * </code>
- * 
+ *
  * @param {Partial<MoneroWalletConfig>} config - config to open a full wallet
  * @param {string} [config.path] - path of the wallet to open (optional if 'keysData' provided)
  * @param {string} [config.password] - password of the wallet to open
@@ -263,9 +263,9 @@ function openWalletFull(config: Partial<MoneroWalletConfig>): Promise<MoneroWall
 
 /**
  * <p>Create a wallet using WebAssembly bindings to monero-project.</p>
- * 
+ *
  * <p>Example:</p>
- * 
+ *
  * <code>
  * const wallet = await moneroTs.createWalletKeys({<br>
  * &nbsp;&nbsp; password: "abc123",<br>
@@ -273,7 +273,7 @@ function openWalletFull(config: Partial<MoneroWalletConfig>): Promise<MoneroWall
  * &nbsp;&nbsp; seed: "coexist igloo pamphlet lagoon..."<br>
  * });
  * </code>
- * 
+ *
  * @param {Partial<MoneroWalletConfig>} config - MoneroWalletConfig or equivalent config object
  * @param {string|number} config.networkType - network type of the wallet to create (one of "mainnet", "testnet", "stagenet" or MoneroNetworkType.MAINNET|TESTNET|STAGENET)
  * @param {string} [config.seed] - seed of the wallet to create (optional, random wallet created if neither seed nor keys given)


### PR DESCRIPTION
This PR adds moneroTs default export so that the module can be imported as:

import moneroTs from "monero-ts";

Resolves #146

For additional comments and details see #163