### PR TITLE
upgrade web-worker to 1.3.0 (add Bun.js support)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "text-encoding": "^0.7.0",
         "tls": "0.0.1",
         "uuid": "3.3.2",
-        "web-worker": "^1.2.0"
+        "web-worker": "^1.3.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.18.10",
@@ -8274,8 +8274,9 @@
       }
     },
     "node_modules/web-worker": {
-      "version": "1.2.0",
-      "license": "Apache-2.0"
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.3.0.tgz",
+      "integrity": "sha512-BSR9wyRsy/KOValMgd5kMyr3JzpdeoR9KVId8u5GVlTTAtNChlsE4yTxeY7zMdNSyOmoKBv8NH2qeRY9Tg+IaA=="
     },
     "node_modules/webpack": {
       "version": "5.88.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "text-encoding": "^0.7.0",
     "tls": "0.0.1",
     "uuid": "3.3.2",
-    "web-worker": "^1.2.0"
+    "web-worker": "^1.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.18.10",


### PR DESCRIPTION
[web-worker 1.3.0](https://github.com/developit/web-worker/releases/tag/1.3.0) [adds Bun support](https://github.com/developit/web-worker/pull/43).