### PR TITLE
Combine wasm + js files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,7 +294,7 @@ EMCC_LINKER_FLAGS_BASE
 -s NODEJS_CATCH_EXIT=0 \
 -s RESERVED_FUNCTION_POINTERS=5 \
 -s EXPORTED_RUNTIME_METHODS='[\"UTF8ToString\",\"stringToUTF8\",\"lengthBytesUTF8\",\"intArrayToString\",\"getTempRet0\",\"addFunction\"]' \
--s WASM=1 \
+-s SINGLE_FILE \
 -s ALLOW_MEMORY_GROWTH=1 \
 -s WASM_BIGINT=1 \
 "

--- a/bin/build_wasm_emscripten.sh
+++ b/bin/build_wasm_emscripten.sh
@@ -18,7 +18,7 @@ cd build || exit 1
 emcmake cmake .. || exit 1
 emmake cmake --build . -j$HOST_NCORES || exit 1
 
-# move available wasm files to ./dist
+# move wasm files to ./dist
 cd ..
 mkdir -p ./dist || exit 1
 [ -f ./build/monero_wallet_keys.js ] \
@@ -26,17 +26,7 @@ mkdir -p ./dist || exit 1
     mv ./build/monero_wallet_keys.js ./dist/
   }
 
-[ -f ./build/monero_wallet_keys.wasm ] \
-  && {
-    mv ./build/monero_wallet_keys.wasm ./dist/
-  }
-
 [ -f ./build/monero_wallet_full.js ] \
   && {
     mv ./build/monero_wallet_full.js ./dist/
-  }
-
-[ -f ./build/monero_wallet_full.wasm ] \
-  && {
-    mv ./build/monero_wallet_full.wasm ./dist/
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build_web_tests": "webpack --config ./webpack.tests.js",
     "test": "npm run build_commonjs && node --enable-source-maps --no-experimental-fetch node_modules/mocha/bin/_mocha --require @babel/register \"dist/src/test/TestAll\" --timeout 900000000 --exit",
     "typedoc": "typedoc ./index.ts --out ./docs/typedocs --excludePrivate --disableSources",
-    "build_commonjs": "babel ./src  --extensions \".js,.ts\" --out-dir ./dist/src && babel ./index.ts  --extensions \".ts\" --out-dir ./dist && shx mkdir -p dist/dist && shx cp dist/monero_wallet_full.js dist/monero_wallet_keys.js dist/dist && shx cp dist/*.js.map dist/dist && shx cp dist/*.wasm dist/dist",
+    "build_commonjs": "babel ./src  --extensions \".js,.ts\" --out-dir ./dist/src && babel ./index.ts  --extensions \".ts\" --out-dir ./dist && shx mkdir -p dist/dist && shx cp dist/monero_wallet_full.js dist/monero_wallet_keys.js dist/dist && shx cp dist/*.js.map dist/dist",
     "check_babel_version": "babel -V"
   },
   "build": {


### PR DESCRIPTION
https://github.com/woodser/monero-ts/issues/83 requests to combine the .wasm files into a single .js file for distribution.

This is working with this PR, however, the .js files are larger than the .wasm + .js files when separated. Maybe that's not a problem.

However, monero_web_worker.js swells to 10.4 mbs, and monero_web_worker.js.map is 14.5 mbs, so these need to be optimized before this PR can be merged. 