### PR TITLE
Combine .wasm and .js files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Oz -s EXCEPTION_CATCHING_ALL
 add_definitions(-DAUTO_INITIALIZE_EASYLOGGINGPP -DNO_AES)
 
 set(BUILD_MONERO_WALLET_FULL_WASM ON)
-set(BUILD_MONERO_WALLET_KEYS_WASM ON)
 
 ##############
 # C++ bridge
@@ -307,12 +306,6 @@ EMCC_LINKER_FLAGS_BASE
 )
 
 set(
-EMCC_LINKER_FLAGS_KEYS
-"${EMCC_LINKER_FLAGS_BASE} \
-"
-)
-
-set(
 EMCC_LINKER_FLAGS_FULL
 "${EMCC_LINKER_FLAGS_BASE} \
 -s ASYNCIFY=1 \
@@ -320,26 +313,11 @@ EMCC_LINKER_FLAGS_FULL
 "
 )
 
-message(STATUS "EMCC_LINKER_FLAGS_KEYS ${EMCC_LINKER_FLAGS_KEYS}")
 message(STATUS "EMCC_LINKER_FLAGS_FULL ${EMCC_LINKER_FLAGS_FULL}")
 
 ####################
 # Build targets
 ####################
-
-if (BUILD_MONERO_WALLET_KEYS_WASM)
-    add_executable(monero_wallet_keys ${MONERO_WALLET_KEYS_SRC_FILES})
-    set_target_properties(monero_wallet_keys PROPERTIES LINK_FLAGS "${EMCC_LINKER_FLAGS_KEYS}")
-    target_link_libraries(
-        monero_wallet_keys
-        #
-        boost_chrono
-        boost_system
-        boost_thread
-        #
-        ${log-lib}
-    )
-endif()
 
 if (BUILD_MONERO_WALLET_FULL_WASM)
     add_executable(monero_wallet_full ${MONERO_WALLET_FULL_SRC_FILES} ${MONERO_WALLET_KEYS_SRC_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,7 +294,7 @@ EMCC_LINKER_FLAGS_BASE
 -s NODEJS_CATCH_EXIT=0 \
 -s RESERVED_FUNCTION_POINTERS=5 \
 -s EXPORTED_RUNTIME_METHODS='[\"UTF8ToString\",\"stringToUTF8\",\"lengthBytesUTF8\",\"intArrayToString\",\"getTempRet0\",\"addFunction\"]' \
--s WASM=1 \
+-s SINGLE_FILE=1 \
 -s ALLOW_MEMORY_GROWTH=1 \
 -s WASM_BIGINT=1 \
 "

--- a/bin/build_dist.sh
+++ b/bin/build_dist.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 ./bin/build_wasm_emscripten.sh || exit 1
+./bin/postprocess_wasm.sh || exit 1
 ./bin/build_web_worker.sh || exit 1
 npm run build_commonjs || exit 1

--- a/bin/build_wasm_emscripten.sh
+++ b/bin/build_wasm_emscripten.sh
@@ -26,17 +26,7 @@ mkdir -p ./dist || exit 1
     mv ./build/monero_wallet_keys.js ./dist/
   }
 
-[ -f ./build/monero_wallet_keys.wasm ] \
-  && {
-    mv ./build/monero_wallet_keys.wasm ./dist/
-  }
-
 [ -f ./build/monero_wallet_full.js ] \
   && {
     mv ./build/monero_wallet_full.js ./dist/
-  }
-
-[ -f ./build/monero_wallet_full.wasm ] \
-  && {
-    mv ./build/monero_wallet_full.wasm ./dist/
   }

--- a/bin/build_wasm_emscripten.sh
+++ b/bin/build_wasm_emscripten.sh
@@ -21,11 +21,6 @@ emmake cmake --build . -j$HOST_NCORES || exit 1
 # move available wasm files to ./dist
 cd ..
 mkdir -p ./dist || exit 1
-[ -f ./build/monero_wallet_keys.js ] \
-  && {
-    mv ./build/monero_wallet_keys.js ./dist/
-  }
-
 [ -f ./build/monero_wallet_full.js ] \
   && {
     mv ./build/monero_wallet_full.js ./dist/

--- a/bin/postprocess_wasm.mjs
+++ b/bin/postprocess_wasm.mjs
@@ -1,0 +1,57 @@
+import fs from "fs";
+import { Buffer } from "buffer";
+
+const fileNames = ["./dist/monero_wallet_full.js", "./dist/monero_wallet_keys.js"];
+
+
+const postprocess = async (fileName) => {
+  // read input file
+  const source = await fs.promises.readFile(fileName, "utf8");
+
+  // do not recompress again
+  if (source.includes("DecompressionStream")) {
+    console.log(`Skipping already compressed file ${fileName}`);
+    return;
+  }
+
+  // find wasmBinaryFile base64 string
+  const match = source.match(/wasmBinaryFile=\"data:application\/octet-stream;base64,(.+?(?=\"))/gm);
+  if (!match?.length) {
+    console.log(`Skipping ${fileName}. wasmBinaryFile not base64 encoded`);
+    return;
+  }
+  const b64 = match[0].split('wasmBinaryFile="data:application/octet-stream;base64,')[1];
+  const buf = Buffer.from(b64, 'base64');
+
+  // compress wasmBinaryFile
+  const compression = new CompressionStream("deflate");
+  const compressedStream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new Uint8Array(buf));
+      controller.close();
+    },
+  }).pipeThrough(compression);
+  const compressedData = await new Response(compressedStream).arrayBuffer();
+
+  // convert compressed wasmBinaryFile to base64
+  const cb64 = Buffer.from(compressedData).toString("base64");
+
+  // replace wasmBinaryFile with compressed wasmBinaryFile and add extra code to decompress it
+  const replaced = source
+    .replace(b64, cb64)
+    .replace(
+      "return intArrayFromBase64(filename.slice(dataURIPrefix.length))",
+      'const data=filename.slice(dataURIPrefix.length);if(data.startsWith("AGFzbQ"))return intArrayFromBase64(data);else{const bin=intArrayFromBase64(data);const ds = new DecompressionStream("deflate");const decompressedStream = new ReadableStream({start(controller){controller.enqueue(bin);controller.close();}}).pipeThrough(ds);return (new Response(decompressedStream)).arrayBuffer();}'
+    )
+    .replace(
+      "!wasmBinary&&(ENVIRONMENT_IS_WEB||ENVIRONMENT_IS_WORKER)",
+      "!wasmBinary&&false"
+    );
+
+  // write output file
+  await fs.promises.writeFile(fileName, replaced);
+}
+
+for (const fileName of fileNames) {
+  await postprocess(fileName);
+}

--- a/bin/postprocess_wasm.mjs
+++ b/bin/postprocess_wasm.mjs
@@ -1,7 +1,7 @@
 import fs from "fs";
 import { Buffer } from "buffer";
 
-const fileNames = ["./dist/monero_wallet_full.js", "./dist/monero_wallet_keys.js"];
+const fileNames = ["./dist/monero_wallet_full.js"];
 
 
 const postprocess = async (fileName) => {

--- a/bin/postprocess_wasm.sh
+++ b/bin/postprocess_wasm.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+set -ex
+node ./bin/postprocess_wasm.mjs

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build_web_tests": "webpack --config ./webpack.tests.js",
     "test": "npm run build_commonjs && node --enable-source-maps node_modules/mocha/bin/_mocha --require @babel/register \"dist/src/test/TestAll\" --timeout 900000000 --exit",
     "typedoc": "typedoc ./index.ts --out ./docs/typedocs --excludePrivate --disableSources",
-    "build_commonjs": "babel ./src  --extensions \".js,.ts\" --out-dir ./dist/src && babel ./index.ts  --extensions \".ts\" --out-dir ./dist && shx mkdir -p dist/dist && shx cp dist/monero_wallet_full.js dist/monero_wallet_keys.js dist/dist && shx cp dist/*.js.map dist/dist && shx cp dist/*.wasm dist/dist",
+    "build_commonjs": "babel ./src  --extensions \".js,.ts\" --out-dir ./dist/src && babel ./index.ts  --extensions \".ts\" --out-dir ./dist && shx mkdir -p dist/dist && shx cp dist/monero_wallet_full.js dist/monero_wallet_keys.js dist/dist && shx cp dist/*.js.map dist/dist",
     "check_babel_version": "babel -V"
   },
   "build": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build_web_tests": "webpack --config ./webpack.tests.js",
     "test": "npm run build_commonjs && node --enable-source-maps node_modules/mocha/bin/_mocha --require @babel/register \"dist/src/test/TestAll\" --timeout 900000000 --exit",
     "typedoc": "typedoc ./index.ts --out ./docs/typedocs --excludePrivate --disableSources",
-    "build_commonjs": "babel ./src  --extensions \".js,.ts\" --out-dir ./dist/src && babel ./index.ts  --extensions \".ts\" --out-dir ./dist && shx mkdir -p dist/dist && shx cp dist/monero_wallet_full.js dist/monero_wallet_keys.js dist/dist && shx cp dist/*.js.map dist/dist",
+    "build_commonjs": "babel ./src  --extensions \".js,.ts\" --out-dir ./dist/src && babel ./index.ts  --extensions \".ts\" --out-dir ./dist && shx mkdir -p dist/dist && shx cp dist/monero_wallet_full.js dist/dist && shx cp dist/*.js.map dist/dist",
     "check_babel_version": "babel -V"
   },
   "build": {

--- a/src/main/ts/common/LibraryUtils.ts
+++ b/src/main/ts/common/LibraryUtils.ts
@@ -80,30 +80,9 @@ export default class LibraryUtils {
   }
   
   /**
-   * Load the WebAssembly keys module with caching.
-   */
-  static async loadKeysModule() {
-    
-    // use cache if suitable, full module supersedes keys module because it is superset
-    if (LibraryUtils.WASM_MODULE) return LibraryUtils.WASM_MODULE;
-    
-    // load module
-    const fetch_ = globalThis.fetch;
-    globalThis.fetch = undefined; // prevent fetch in worker
-    let module = await require("../../../../dist/monero_wallet_keys")();
-    globalThis.fetch = fetch_;
-    LibraryUtils.WASM_MODULE = module;
-    delete LibraryUtils.WASM_MODULE.then;
-    LibraryUtils.initWasmModule(LibraryUtils.WASM_MODULE);
-    return module;
-  }
-  
-  /**
    * Load the WebAssembly full module with caching.
    * 
    * The full module is a superset of the keys module and overrides it.
-   * 
-   * TODO: this is separate static function from loadKeysModule() because webpack cannot bundle worker using runtime param for conditional import
    */
   static async loadFullModule() {
     

--- a/src/main/ts/common/MoneroRpcConnection.ts
+++ b/src/main/ts/common/MoneroRpcConnection.ts
@@ -182,7 +182,7 @@ export default class MoneroRpcConnection {
    */
   async checkConnection(timeoutMs): Promise<boolean> {
     return this.queueCheckConnection(async () => {
-      await LibraryUtils.loadKeysModule(); // cache wasm for binary request
+      await LibraryUtils.loadFullModule(); // cache wasm for binary request
       let isOnlineBefore = this.isOnline;
       let isAuthenticatedBefore = this.isAuthenticated;
       let startTime = Date.now();

--- a/src/main/ts/common/MoneroUtils.ts
+++ b/src/main/ts/common/MoneroUtils.ts
@@ -162,7 +162,7 @@ export default class MoneroUtils {
     assert(GenUtils.isBase58(standardAddress), "Address is not base 58");
     
     // load keys module by default
-    if (LibraryUtils.getWasmModule() === undefined) await LibraryUtils.loadKeysModule();
+    if (LibraryUtils.getWasmModule() === undefined) await LibraryUtils.loadFullModule();
     
     // get integrated address in queue
     return LibraryUtils.getWasmModule().queueTask(async () => {
@@ -204,7 +204,7 @@ export default class MoneroUtils {
     networkType = MoneroNetworkType.from(networkType);
     
     // load keys module by default
-    if (LibraryUtils.getWasmModule() === undefined) await LibraryUtils.loadKeysModule();
+    if (LibraryUtils.getWasmModule() === undefined) await LibraryUtils.loadFullModule();
     
     // validate address in queue
     return LibraryUtils.getWasmModule().queueTask(async function() {
@@ -308,7 +308,7 @@ export default class MoneroUtils {
     if (MoneroUtils.PROXY_TO_WORKER) return LibraryUtils.invokeWorker(undefined, "moneroUtilsJsonToBinary", Array.from(arguments));
     
     // load keys module by default
-    if (LibraryUtils.getWasmModule() === undefined) await LibraryUtils.loadKeysModule();
+    if (LibraryUtils.getWasmModule() === undefined) await LibraryUtils.loadFullModule();
     
     // use wasm in queue
     return LibraryUtils.getWasmModule().queueTask(async function() {
@@ -345,7 +345,7 @@ export default class MoneroUtils {
     if (MoneroUtils.PROXY_TO_WORKER) return LibraryUtils.invokeWorker(undefined, "moneroUtilsBinaryToJson", Array.from(arguments));
     
     // load keys module by default
-    if (LibraryUtils.getWasmModule() === undefined) await LibraryUtils.loadKeysModule();
+    if (LibraryUtils.getWasmModule() === undefined) await LibraryUtils.loadFullModule();
     
     // use wasm in queue
     return LibraryUtils.getWasmModule().queueTask(async function() {
@@ -382,7 +382,7 @@ export default class MoneroUtils {
     if (MoneroUtils.PROXY_TO_WORKER) return LibraryUtils.invokeWorker(undefined, "moneroUtilsBinaryBlocksToJson", Array.from(arguments));
     
     // load keys module by default
-    if (LibraryUtils.getWasmModule() === undefined) await LibraryUtils.loadKeysModule();
+    if (LibraryUtils.getWasmModule() === undefined) await LibraryUtils.loadFullModule();
     
     // use wasm in queue
     return LibraryUtils.getWasmModule().queueTask(async function() {

--- a/src/main/ts/wallet/MoneroWalletKeys.ts
+++ b/src/main/ts/wallet/MoneroWalletKeys.ts
@@ -83,7 +83,7 @@ export class MoneroWalletKeys extends MoneroWallet {
     if (config.getLanguage() === undefined) config.setLanguage("English");
     
     // load wasm module
-    let module = await LibraryUtils.loadKeysModule();
+    let module = await LibraryUtils.loadFullModule();
     
     // queue call to wasm module
     return module.queueTask(async () => {
@@ -107,7 +107,7 @@ export class MoneroWalletKeys extends MoneroWallet {
     if (config.getLanguage() !== undefined) throw new MoneroError("Cannot provide language when creating wallet from seed");
     
     // load wasm module
-    let module = await LibraryUtils.loadKeysModule();
+    let module = await LibraryUtils.loadFullModule();
     
     // queue call to wasm module
     return module.queueTask(async () => {
@@ -133,7 +133,7 @@ export class MoneroWalletKeys extends MoneroWallet {
     if (config.getLanguage() === undefined) config.setLanguage("English");
     
     // load wasm module
-    let module = await LibraryUtils.loadKeysModule();
+    let module = await LibraryUtils.loadFullModule();
     
     // queue call to wasm module
     return module.queueTask(async () => {
@@ -149,7 +149,7 @@ export class MoneroWalletKeys extends MoneroWallet {
   }
   
   static async getSeedLanguages(): Promise<string[]> {
-    let module = await LibraryUtils.loadKeysModule();
+    let module = await LibraryUtils.loadFullModule();
     return module.queueTask(async () => {
       return JSON.parse(module.get_keys_wallet_seed_languages()).languages;
     });

--- a/src/test/TestMoneroWalletCommon.ts
+++ b/src/test/TestMoneroWalletCommon.ts
@@ -70,7 +70,7 @@ export default class TestMoneroWalletCommon {
     this.wallet = await this.getTestWallet();
     this.daemon = await this.getTestDaemon();
     TestUtils.WALLET_TX_TRACKER.reset(); // all wallets need to wait for txs to confirm to reliably sync
-    await LibraryUtils.loadKeysModule(); // for wasm dependents like address validation
+    await LibraryUtils.loadFullModule(); // for wasm dependents like address validation
   }
   
   /**


### PR DESCRIPTION
* Compile wasms into single file
* Use postprocessing to compress the base64 encoded wasms
* Add new way to load web worker

The latter is especially useful in browsers. Place the following line
```
LibraryUtils.setWorkerLoader(() => new Worker(new URL("monero-ts/dist/monero_web_worker.js", import.meta.url)));
```
before interacting with any code which relies on webworker.

Resolves https://github.com/woodser/monero-ts/issues/248