### PR TITLE
Fix handling of internal assets to eliminate the need for dist/dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,16 @@
     "CMakeListst.txt",
     "LICENSE.txt"
   ],
+  "imports": {
+    "#monero-ts/monero.js": "./dist/monero.js"
+  },
   "scripts": {
     "start": "todo",
     "build_web_worker": "webpack --config ./webpack.worker.js",
     "build_web_tests": "webpack --config ./webpack.tests.js",
     "test": "npm run build_commonjs && node --enable-source-maps node_modules/mocha/bin/_mocha --require @babel/register \"dist/src/test/TestAll\" --timeout 900000000 --exit",
     "typedoc": "typedoc ./index.ts --out ./docs/typedocs --excludePrivate --disableSources",
-    "build_commonjs": "babel ./src  --extensions \".js,.ts\" --out-dir ./dist/src && babel ./index.ts  --extensions \".ts\" --out-dir ./dist && shx mkdir -p dist/dist && shx cp dist/monero.js dist/dist && shx cp dist/*.js.map dist/dist",
+    "build_commonjs": "babel ./src  --extensions \".js,.ts\" --out-dir ./dist/src && babel ./index.ts  --extensions \".ts\" --out-dir ./dist",
     "check_babel_version": "babel -V"
   },
   "build": {

--- a/src/main/cpp/http_client_wasm.cpp
+++ b/src/main/cpp/http_client_wasm.cpp
@@ -12,10 +12,9 @@ using namespace std;
 EM_JS(const char*, js_send_json_request, (const char* uri, const char* username, const char* password, const char* reject_unauthorized_fn_id, const char* method, const char* body, std::chrono::milliseconds timeout), {
   //console.log("EM_JS js_send_json_request(" + UTF8ToString(uri) + ", " + UTF8ToString(username) + ", " + UTF8ToString(password) + ", " + UTF8ToString(method) + ")");
 
-  const moneroTs = require("../index");
-  const HttpClient = moneroTs.HttpClient;
-  const LibraryUtils = moneroTs.LibraryUtils;
-  const GenUtils = moneroTs.GenUtils;
+  const HttpClient = this.HttpClient;
+  const LibraryUtils = this.LibraryUtils;
+  const GenUtils = this.GenUtils;
 
   // use asyncify to synchronously return to C++
   return Asyncify.handleSleep(function(wakeUp) {
@@ -66,10 +65,9 @@ EM_JS(const char*, js_send_json_request, (const char* uri, const char* username,
 EM_JS(const char*, js_send_binary_request, (const char* uri, const char* username, const char* password, const char* reject_unauthorized_fn_id, const char* method, const char* body, int body_length, std::chrono::milliseconds timeout), {
   //console.log("EM_JS js_send_binary_request(" + UTF8ToString(uri) + ", " + UTF8ToString(username) + ", " + UTF8ToString(password) + ", " + UTF8ToString(method) + ")");
 
-  const moneroTs = require("../index");
-  const HttpClient = moneroTs.HttpClient;
-  const LibraryUtils = moneroTs.LibraryUtils;
-  const GenUtils = moneroTs.GenUtils;
+  const HttpClient = this.HttpClient;
+  const LibraryUtils = this.LibraryUtils;
+  const GenUtils = this.GenUtils;
 
   // use asyncify to synchronously return to C++
   return Asyncify.handleSleep(function(wakeUp) {

--- a/src/main/ts/common/LibraryUtils.ts
+++ b/src/main/ts/common/LibraryUtils.ts
@@ -90,7 +90,7 @@ export default class LibraryUtils {
     if (LibraryUtils.WASM_MODULE && LibraryUtils.FULL_LOADED) return LibraryUtils.WASM_MODULE;
     
     // load module
-    let module = await require("../../../../dist/monero")();
+    const module = await require("#monero-ts/monero.js")();
     LibraryUtils.WASM_MODULE = module;
     delete LibraryUtils.WASM_MODULE.then;
     LibraryUtils.FULL_LOADED = true;

--- a/src/main/ts/common/MoneroWebWorker.ts
+++ b/src/main/ts/common/MoneroWebWorker.ts
@@ -21,6 +21,11 @@ import MoneroWalletFull from "../wallet/MoneroWalletFull";
 
 declare const self: any;
 
+// expose some modules to the worker
+self.HttpClient = HttpClient;
+self.LibraryUtils = LibraryUtils;
+self.GenUtils = GenUtils;
+
 /**
  * Worker to manage a daemon and wasm wallet off the main thread using messages.
  * 

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -39,12 +39,10 @@ let configBase = {
       extensions: ['.js', '.ts'],
       alias: {
         "fs": "memfs",
-        ['~']: path.resolve(__dirname + '/app')
       },
       extensions: ['.js', '.jsx', '.css', '.json', 'otf', 'ttf', 'eot', 'svg', '.ts', '.tsx'],
       modules: [
         'node_modules',
-        path.resolve(__dirname + '/src')
       ],
       fallback: { // browser polyfills
         assert: require.resolve('assert'),


### PR DESCRIPTION
`const moneroTs = require("../index");`

the above statement while being totally unnecessary and wasteful also broke the import patterns in browser and node: the former expected "./index", the latter "../index". Also it did break the multithreading upgrade which I have explored recently.

Exposing `HttpClient` and some other submodules to the worker scope is just fine, it does not increase the dist size too.