### PR TITLE
Fixes errors in sample Deno project 

### DIFF
--- a/src/main/ts/common/HttpClient.ts
+++ b/src/main/ts/common/HttpClient.ts
@@ -185,7 +185,7 @@ export default class HttpClient {
       httpsAgent: url.startsWith("https") ? HttpClient.getHttpsAgent() : undefined,
       data: body,
       transformResponse: res => res,
-      adapter: ['http', 'xhr', 'fetch'],
+      adapter: LibraryUtils.isUsingDeno() ? ['fetch'] : ['http', 'xhr', 'fetch']
     }).catch(async (err) => {
       if (err.response?.status === 401) {
         let authHeader = err.response.headers['www-authenticate'].replace(/,\sDigest.*/, "");
@@ -232,7 +232,7 @@ export default class HttpClient {
           httpsAgent: url.startsWith("https") ? HttpClient.getHttpsAgent() : undefined,
           data: body,
           transformResponse: res => res,
-          adapter: ['http', 'xhr', 'fetch'],
+          adapter: LibraryUtils.isUsingDeno() ? ['fetch'] : ['http', 'xhr', 'fetch']
         });
 
         return finalResponse;

--- a/src/main/ts/common/LibraryUtils.ts
+++ b/src/main/ts/common/LibraryUtils.ts
@@ -22,6 +22,7 @@ export default class LibraryUtils {
     // get worker path in dist (assumes library is running from src or dist)
     let curPath = path.normalize(__dirname);
     const targetPath = path.join('monero-ts', 'dist');
+    if (LibraryUtils.isUsingDeno()) return path.join("file://", curPath, !curPath.includes(targetPath) ? "../../../../../dist/src/main/ts/common" : "", "./MoneroWebWorker.js");
     if (!curPath.includes(targetPath)) curPath = path.join(curPath, "../../../../dist/src/main/js/common");
     return LibraryUtils.prefixWindowsPath(path.join(curPath, "./MoneroWebWorker.js"));
   }();
@@ -163,6 +164,8 @@ export default class LibraryUtils {
         // otherwise use standard loading mechanisms for browser and node
         if (GenUtils.isBrowser()) {
           LibraryUtils.WORKER = new Worker(LibraryUtils.WORKER_DIST_PATH);
+        } else if (LibraryUtils.isUsingDeno()) {
+          LibraryUtils.WORKER = new Worker(LibraryUtils.WORKER_DIST_PATH, { type: "module" });
         } else {
           const Worker = require("web-worker"); // import web worker if nodejs
           LibraryUtils.WORKER = new Worker(LibraryUtils.WORKER_DIST_PATH);
@@ -271,6 +274,13 @@ export default class LibraryUtils {
     } catch (err) {
       return false;
     }
+  }
+
+  /**
+   * Get whether or not we are running under Deno by checking for the existence of the global Deno variable.
+   */
+  static isUsingDeno() {
+    return typeof Deno === "object" && Deno.hasOwnProperty("version") && typeof Deno.version === "object" && Deno.version.hasOwnProperty("deno") && typeof Deno.version.deno === "string";
   }
   
   // ------------------------------ PRIVATE HELPERS ---------------------------

--- a/src/main/ts/common/MoneroWebWorker.ts
+++ b/src/main/ts/common/MoneroWebWorker.ts
@@ -20,6 +20,9 @@ import {MoneroWalletKeys} from "../wallet/MoneroWalletKeys";
 import MoneroWalletFull from "../wallet/MoneroWalletFull";
 
 declare const self: any;
+if (LibraryUtils.isUsingDeno() && typeof self === "undefined" && typeof globalThis === "object" && typeof DedicatedWorkerGlobalScope === "function" && DedicatedWorkerGlobalScope.prototype.isPrototypeOf(globalThis)) {
+  self = globalThis;
+}
 
 // expose some modules to the worker
 self.HttpClient = HttpClient;


### PR DESCRIPTION
Closes #274.

**Worker Errors**
Deno doesn't allow classic workers, so the type must be specified as a module type. Deno's Worker class also had to be used in place of web-worker's Worker. Trying to use a web-worker causes issues because the module will still seem to use Deno's Worker behind the scenes, then try do operations on it that are not allowed because of how they're defined by Deno.
There was also an error that had to be addressed where self is seemingly undefined. Normally it's assigned the worker's global scope. Why it isn't here, I'm not sure. Maybe a bug? Either way, we assign the globalThis to it after checking that it's a DedicatedWorkerGlobalScope.

**Unauthorized Error**
HTTP digest authentification requires the underlying socket to be the same from the initial probe request to the subsequent authenticated request. Once the socket is closed, the authentication headers generated using that socket's issued nonce are invalid. Any requests using those headers will be prompted with new values to generate fresh headers(under a 401 response). For whatever reason, the socket/connection wasn't being kept alive under the axios http adapter despite the agent being configured for it. I suspect the http adapter is using Deno's polyfilled http module, which might close the sockets prematurely. Since there's no way to specify to Axios to use "node:http" instead, that adapter can't be used. The xhr adapter is apparently unsupported for Deno so it's out too. That leaves the fetch adapter. It seems to work as expected by keeping the connection alive. As such, it was set to now be the adapter used when running under Deno.