### PR TITLE
build: generate wallet crypto ops.h in wasm build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,10 @@ include_directories("${MONERO_PROJECT}/contrib/epee/include/net")
 #include_directories("${MONERO_PROJECT_SRC}/wallet/api")
 
 include_directories("${MONERO_PROJECT}/build/release/translations")
-include_directories("${MONERO_PROJECT}/build/release/generated_include")
+
+# generate empty crypto/wallet/ops.h to select monero-project's internal wallet crypto (supercop asm is not wasm-compatible)
+configure_file("${MONERO_PROJECT_SRC}/crypto/wallet/empty.h.in" "${CMAKE_BINARY_DIR}/generated_include/crypto/wallet/ops.h" COPYONLY)
+include_directories("${CMAKE_BINARY_DIR}/generated_include")
 
 #############
 # Unbound

--- a/README.md
+++ b/README.md
@@ -160,9 +160,8 @@ Compiled WebAssembly binaries are committed to ./dist for convenience, but these
 2. Clone monero-ts repository: `git clone --recursive https://github.com/woodser/monero-ts.git`
 3. `cd monero-ts`
 4. `./bin/update_submodules.sh`
-5. Modify ./external/monero-cpp/external/monero-project/src/crypto/wallet/CMakeLists.txt from `set(MONERO_WALLET_CRYPTO_LIBRARY "auto" ...` to `set(MONERO_WALLET_CRYPTO_LIBRARY "cn" ...`.
-6. Build the monero-cpp submodule (located at ./external/monero-cpp) by following [instructions](https://github.com/woodser/monero-cpp#using-monero-cpp-in-your-project) for your system. This will ensure all dependencies are installed. Be sure to install unbound 1.19.0 to your home directory (`~/unbound-1.19.0`).
-7. `./bin/build_all.sh` (install [monero-project dependencies](https://github.com/monero-project/monero#dependencies) as needed for your system)
+5. Build the monero-cpp submodule (located at ./external/monero-cpp) by following [instructions](https://github.com/woodser/monero-cpp#using-monero-cpp-in-your-project) for your system. This will ensure all dependencies are installed. Be sure to install unbound 1.19.0 to your home directory (`~/unbound-1.19.0`).
+6. `./bin/build_all.sh` (install [monero-project dependencies](https://github.com/monero-project/monero#dependencies) as needed for your system)
 
 ## Running tests
 

--- a/docs/typedocs/index.html
+++ b/docs/typedocs/index.html
@@ -89,7 +89,6 @@
 <li>Clone monero-ts repository: <code>git clone --recursive https://github.com/woodser/monero-ts.git</code></li>
 <li><code>cd monero-ts</code></li>
 <li><code>./bin/update_submodules.sh</code></li>
-<li>Modify ./external/monero-cpp/external/monero-project/src/crypto/wallet/CMakeLists.txt from <code>set(MONERO_WALLET_CRYPTO_LIBRARY &quot;auto&quot; ...</code> to <code>set(MONERO_WALLET_CRYPTO_LIBRARY &quot;cn&quot; ...</code>.</li>
 <li>Build the monero-cpp submodule (located at ./external/monero-cpp) by following <a href="https://github.com/woodser/monero-cpp#using-monero-cpp-in-your-project">instructions</a> for your system. This will ensure all dependencies are installed. Be sure to install unbound 1.19.0 to your home directory (<code>~/unbound-1.19.0</code>).</li>
 <li><code>./bin/build_all.sh</code> (install <a href="https://github.com/monero-project/monero#dependencies">monero-project dependencies</a> as needed for your system)</li>
 </ol>


### PR DESCRIPTION
Copy monero-project's empty.h.in to select internal wallet crypto, removing the README step to edit the submodule's CMakeLists.